### PR TITLE
Bump Node.js test versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,8 +8,8 @@ notifications:
 language: node_js
 node_js:
   - "0.12"
-  - "4.2"
-  - "5.0"
+  - "4.4"
+  - "6.0"
 
 env:
   - CXX=g++-4.8


### PR DESCRIPTION
4.2.x and 4.3.x are superseded by 4.4.x.  6.0.x supercedes 5.x.